### PR TITLE
Removing the authorization in the header for testing

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ const options = {
   method: 'GET', 
   headers: { 
     accept: "application/json",
-    'Authorization': `Bearer ${apiKey}`
     }
   };
 


### PR DESCRIPTION
Conflicting information in the OpenAQ guidance into the request header, removing authorization for testing
