### PR TITLE
Modifying the fetch url to sort through OpenAQ array

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,7 +10,7 @@ const options = {
     }
   };
 
-  fetch(`https://api.openaq.org/v2/measurements?city=${encodedCity}`, options) 
+  fetch(`https://api.openaq.org/v2/measurements?city=${encodedCity}&sort=desc&limit=1`, options) 
     .then(response => response.json())
     .then(data => {
       console.log(data);


### PR DESCRIPTION
- Previous change worked to retrieve results from the array, but 100 results were gathered
- Adding filtering to the fetch URL to fetch just one result from the start of the array